### PR TITLE
Update to account if applications use single quotes instead of double quotes

### DIFF
--- a/link.go
+++ b/link.go
@@ -13,7 +13,7 @@ var (
 	keyRegexp        = regexp.MustCompile(`[a-z*]+`)
 	linkRegexp       = regexp.MustCompile(`\A<(.+)>;(.+)\z`)
 	semiRegexp       = regexp.MustCompile(`; +`)
-	valRegexp        = regexp.MustCompile(`"+([^"]+)"+`)
+	valRegexp        = regexp.MustCompile(`"|'+([^"]|[^']+)(?:"|')+`)
 )
 
 // Group returned by Parse, contains multiple links indexed by "rel"

--- a/link.go
+++ b/link.go
@@ -81,9 +81,16 @@ func Parse(s string) Group {
 
 		for _, extra := range semiRegexp.Split(pieces[2], -1) {
 			vals := equalRegexp.Split(extra, -1)
+			if len(vals) < 2 {
+				continue
+			}
 
 			key := keyRegexp.FindString(vals[0])
-			val := valRegexp.FindStringSubmatch(vals[1])[1]
+			submatch := valRegexp.FindStringSubmatch(vals[1])
+			if len(submatch) < 2 {
+				continue
+			}
+			val := submatch[1]
 
 			if key == "rel" {
 				vals := strings.Split(val, " ")

--- a/link.go
+++ b/link.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	commaRegexp      = regexp.MustCompile(`,\s{0,}`)
-	valueCommaRegexp = regexp.MustCompile(`([^"]),`)
+	valueCommaRegexp = regexp.MustCompile(`([^'"]),`)
 	equalRegexp      = regexp.MustCompile(` *= *`)
 	keyRegexp        = regexp.MustCompile(`[a-z*]+`)
 	linkRegexp       = regexp.MustCompile(`\A<(.+)>;(.+)\z`)

--- a/link.go
+++ b/link.go
@@ -13,7 +13,7 @@ var (
 	keyRegexp        = regexp.MustCompile(`[a-z*]+`)
 	linkRegexp       = regexp.MustCompile(`\A<(.+)>;(.+)\z`)
 	semiRegexp       = regexp.MustCompile(`; +`)
-	valRegexp        = regexp.MustCompile(`"|'+([^"]|[^']+)(?:"|')+`)
+	valRegexp        = regexp.MustCompile(`(?:"|')+([^'"]+)(?:'|")+`)
 )
 
 // Group returned by Parse, contains multiple links indexed by "rel"


### PR DESCRIPTION
Update to account if applications use single quotes instead of double quotes.
Example:

```go
resp := &http.Response{Header: http.Header{}}
resp.Header.Set("Link", `<https://example.com/?page=2>; rel='next'`)
```

In its current state if you have rel with single quotes, the application panics.  I have updated the regex to match single quotes, and I have updated the application to avoid panics.